### PR TITLE
ci: build datum inside the CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,31 @@
+name: Build DATUM Gateway
+
+on:
+    schedule:
+        - cron: '0 0 1 * *'
+    push:
+        branches:
+            - master
+    pull_request:
+        branches:
+            - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Create build directory
+        run: mkdir -p build
+        
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev libjansson-dev libmicrohttpd-dev libsodium-dev
+      
+      - name: Build DATUM Gateway
+        run: |
+          cd build
+          cmake ..
+          make -j$(nproc)


### PR DESCRIPTION
As this could be a potential spam point for our GitHub because people might submit code without verifying if it compiles.

However, having this inside the CI allows us to cover a basic compilation test, which for some contributions may not require a full build. Additionally, we can ensure that the code compiles on basic Linux OS environments, like Ubuntu, or detect if there are any dependency breaks (even with minimal dependencies, so this shouldn't be an issue either).